### PR TITLE
Fix HowlConstructor.value is not a constructor error

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,15 @@ export default {
 }
 </script>
 ```
+## Vite
 
+If you are using Vite, you should add the following to your defineConfig options in vite.config.js:
+
+```js
+optimizeDeps: {
+  exclude: ['vue-demi']
+}
+```
 
 ## Nuxt
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,7 +24,7 @@ export function useSound(
   onMounted(async () => {
     const howler = await import('howler')
 
-    HowlConstructor.value = howler.Howl
+    HowlConstructor.value = howler.default.Howl
 
     sound.value = new HowlConstructor.value({
       src: unref(url) as string,


### PR DESCRIPTION
I had to make 2 changes to get the package working in a fresh Vite CLI app (vue 3).

1. Change the HowlConstructor
2a. _Either_ import onMounted from 'vue' instead of 'vue-demi' (as mentioned here https://github.com/vueuse/sound/issues/27#issuecomment-1331039335)
2b. _Or_ add the vite config option to disable pre-bundling of vue-demi in my own app.

I thought 2b was the better option.

Only tested on a Vite CLI app.