### PR TITLE
export ComposableOptions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,10 @@ import type { Howl } from 'howler'
 import { onMounted, ref, unref, watch } from 'vue-demi'
 import type { ComposableOptions, HowlStatic, MaybeRef, PlayFunction, PlayOptions, ReturnedValue } from './types'
 
+export type {
+  ComposableOptions
+}
+
 export function useSound(
   url: MaybeRef<string>,
   { volume = 1, playbackRate = 1, soundEnabled = true, interrupt = false, autoplay = false, onload, ...delegated }: ComposableOptions = {},


### PR DESCRIPTION
Can't use `ComposableOptions` inside a composable right now if the options are flowing from outside.
This fixes as it would export the `ComposableOptions` in the type declaration and can be extended.

<img width="1001" alt="image" src="https://github.com/vueuse/sound/assets/41203791/a27c3cb9-3506-44b6-a9d0-f9476ce5156f">
