### PR TITLE
chore: fix sprite id type

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -22,7 +22,7 @@ export type ComposableOptions = {
 } & Omit<HowlOptions, 'src'>
 
 export interface PlayOptions {
-  id?: number
+  id?: string | number
   forceSoundEnabled?: boolean
   playbackRate?: number
 }


### PR DESCRIPTION
Sprite ID's uses string type
```
const { play } = useSound('/path/to/sprite.mp3', {
  sprite: {
    laser: [0, 300],
    explosion: [1000, 300],
    meow: [2000, 75],
  },
})
```
My commit fix type issue while call `play` cb
```
play({ id: 'kick' })
```